### PR TITLE
Introduce SlotClock to BeaconChain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2910,6 +2910,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "primitive-types 0.12.1",
  "serde_yaml 0.9.14",
+ "slot_clock",
  "smallvec",
  "tiny-keccak",
  "tokio",
@@ -3459,6 +3460,17 @@ dependencies = [
  "trackable",
  "winapi",
  "windows-acl",
+]
+
+[[package]]
+name = "slot_clock"
+version = "0.2.0"
+source = "git+https://github.com/ackintosh/lighthouse.git?rev=63e8d895d1e416bb5fb94bec178fc6f138602493#63e8d895d1e416bb5fb94bec178fc6f138602493"
+dependencies = [
+ "lazy_static",
+ "lighthouse_metrics",
+ "parking_lot 0.12.1",
+ "types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,35 +11,33 @@ rust-version = "1.61"
 # see https://github.com/ackintosh/lighthouse/pull/4
 
 [dependencies]
-# NOTE: Specifying the latest revision. This should be updated once the next version is released.
-discv5 = "0.1.0"
-futures = "0.3.25"
 delay_map = "0.1.2"
+discv5 = "0.1.0"
+eth2_ssz = { git = "https://github.com/ackintosh/lighthouse.git", rev = "63e8d895d1e416bb5fb94bec178fc6f138602493" }
+eth2_ssz_derive = { git = "https://github.com/ackintosh/lighthouse.git", rev = "63e8d895d1e416bb5fb94bec178fc6f138602493" }
+futures = "0.3.25"
 hex = "0.4.3"
+libp2p = { version = "0.48.0", default-features = false, features = ["dns-tokio", "noise", "mplex", "secp256k1", "tcp-tokio", "yamux"] }
 # Switched to the forked version so use the codec implemented in lighthouse.
 # SEE: https://github.com/ackintosh/lighthouse/compare/unstable...ackintosh:lighthouse:publish-codec
 lighthouse_network = { git = "https://github.com/ackintosh/lighthouse.git", rev = "63e8d895d1e416bb5fb94bec178fc6f138602493" }
 lru = "0.8.1"
-primitive-types = "0.12.1"
 parking_lot = "0.12.1"
+primitive-types = "0.12.1"
 serde_yaml = "0.9.14"
 smallvec = "1.10.0"
 slot_clock = { git = "https://github.com/ackintosh/lighthouse", rev = "63e8d895d1e416bb5fb94bec178fc6f138602493" }
-types = { git = "https://github.com/ackintosh/lighthouse.git", rev = "63e8d895d1e416bb5fb94bec178fc6f138602493" }
-eth2_ssz = { git = "https://github.com/ackintosh/lighthouse.git", rev = "63e8d895d1e416bb5fb94bec178fc6f138602493" }
-eth2_ssz_derive = { git = "https://github.com/ackintosh/lighthouse.git", rev = "63e8d895d1e416bb5fb94bec178fc6f138602493" }
 tiny-keccak = { version = "2.0.2", features = ["keccak"] }
-tracing = "0.1"
-tracing-subscriber = "0.3"
 tokio = { version = "1.21.2", features = ["full"] }
 tokio-io-timeout = "1.2.0"
 # NOTE: Build fails if we upadte tokio-util >= 0.7.0.
 # -> RpcProtocol::upgrade_inbound()
 # https://github.com/tokio-rs/tokio/blob/master/tokio-util/CHANGELOG.md
 tokio-util = { version = "=0.6.10", features = ["codec", "compat"] }
+tracing = "0.1"
+tracing-subscriber = "0.3"
+types = { git = "https://github.com/ackintosh/lighthouse.git", rev = "63e8d895d1e416bb5fb94bec178fc6f138602493" }
 void = "1.0.2"
-
-libp2p = { version = "0.48.0", default-features = false, features = ["dns-tokio", "noise", "mplex", "secp256k1", "tcp-tokio", "yamux"] }
 
 [build-dependencies]
 zip = "0.6.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ primitive-types = "0.12.1"
 parking_lot = "0.12.1"
 serde_yaml = "0.9.14"
 smallvec = "1.10.0"
+slot_clock = { git = "https://github.com/ackintosh/lighthouse", rev = "63e8d895d1e416bb5fb94bec178fc6f138602493" }
 types = { git = "https://github.com/ackintosh/lighthouse.git", rev = "63e8d895d1e416bb5fb94bec178fc6f138602493" }
 eth2_ssz = { git = "https://github.com/ackintosh/lighthouse.git", rev = "63e8d895d1e416bb5fb94bec178fc6f138602493" }
 eth2_ssz_derive = { git = "https://github.com/ackintosh/lighthouse.git", rev = "63e8d895d1e416bb5fb94bec178fc6f138602493" }

--- a/src/network.rs
+++ b/src/network.rs
@@ -29,7 +29,7 @@ struct Executor(Weak<Runtime>);
 impl libp2p::core::Executor for Executor {
     fn exec(&self, f: Pin<Box<dyn Future<Output = ()> + Send>>) {
         if let Some(runtime) = self.0.upgrade() {
-            info!("Executor: Spawning a task");
+            trace!("Executor: Spawning a task");
             runtime.spawn(f);
         } else {
             warn!("Executor: Couldn't spawn task. Runtime shutting down");

--- a/src/peer_db.rs
+++ b/src/peer_db.rs
@@ -65,12 +65,12 @@ impl PeerDB {
     pub(crate) fn update_sync_status(&mut self, peer_id: &PeerId, sync_status: SyncStatus) {
         match self.peers.get_mut(peer_id) {
             None => {
-                error!("update_sync_status: Peer not found. peer_id: {}", peer_id);
+                error!("[{}] update_sync_status: Peer not found.", peer_id);
             }
             Some(peer_info) => {
                 info!(
-                    "Updated sync_status: before: {:?}, after: {:?}, peer: {}",
-                    peer_info.sync_status, sync_status, peer_id
+                    "[{}] Updated sync_status: before: {:?}, after: {:?}",
+                    peer_id, peer_info.sync_status, sync_status
                 );
                 peer_info.sync_status = sync_status;
             }

--- a/src/peer_manager/mod.rs
+++ b/src/peer_manager/mod.rs
@@ -7,7 +7,7 @@ use smallvec::{smallvec, SmallVec};
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::info;
+use tracing::{info, trace};
 
 pub(crate) mod behaviour;
 
@@ -89,6 +89,8 @@ impl PeerManager {
         peer_id: &PeerId,
         reason: lighthouse_network::rpc::GoodbyeReason,
     ) {
+        trace!("[{}] sending goodbye to the peer.", peer_id);
+
         let mut guard = self.peer_db.write();
 
         if matches!(

--- a/src/rpc/behaviour.rs
+++ b/src/rpc/behaviour.rs
@@ -147,7 +147,7 @@ impl NetworkBehaviour for Behaviour {
         _cx: &mut Context<'_>,
         _params: &mut impl PollParameters,
     ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
-        trace!("poll");
+        // trace!("poll");
 
         if !self.events.is_empty() {
             return Poll::Ready(self.events.remove(0));

--- a/src/rpc/handler.rs
+++ b/src/rpc/handler.rs
@@ -313,7 +313,7 @@ impl ConnectionHandler for Handler {
             Self::Error,
         >,
     > {
-        trace!("poll");
+        // trace!("poll");
 
         // /////////////////////////////////////////////////////////////////////////////////////////////////
         // Check if we are shutting down, and if the timer ran out


### PR DESCRIPTION
Introduce `SlotClock` to `BeaconChain` in order to create a correct `EnrForkId` so that we can check the relevance between remote status and ours correctly (in `BeaconChain::is_relevant()`).