### PR TITLE
Fix use of deprecated constants

### DIFF
--- a/src/behaviour.rs
+++ b/src/behaviour.rs
@@ -26,7 +26,7 @@ pub(crate) enum BehaviourComposerEvent {
 
 /// The core behaviour that combines the sub-behaviours.
 #[derive(NetworkBehaviour)]
-#[behaviour(out_event = "BehaviourComposerEvent")]
+#[behaviour(to_swarm = "BehaviourComposerEvent")]
 pub(crate) struct BehaviourComposer<AppReqId: ReqId> {
     /* Sub-Behaviours */
     pub(crate) discovery: crate::discovery::behaviour::Behaviour,


### PR DESCRIPTION
```
warning: use of deprecated constant `behaviour::out_event_renamed_to_to_swarm::_w`: The `out_event` attribute has been renamed to `to_swarm`.
  --> src/behaviour.rs:29:13
   |
29 | #[behaviour(out_event = "BehaviourComposerEvent")]
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default
```